### PR TITLE
Fix admin drop down position

### DIFF
--- a/templates/css/ctrlmm.css
+++ b/templates/css/ctrlmm.css
@@ -87,3 +87,7 @@ div.ilMainMenuRight {
 	float: right !important;
 	padding-right: 20px !important;
 }
+
+#ilAdvSelListAnchorElement_dd_adm {
+	height: inherit;
+}


### PR DESCRIPTION
With the CtrlMainMenu plugin the position of the admin drop down is at the top of the main menu instead of below it. This happens because the preceding span tag has a hight of 0 (without the plugin this is not the case).
This is a simple solution to set the hight to the one of the parent element.
