### PR TITLE
Avoid unnecessary asynchronous calls

### DIFF
--- a/templates/js/check.js
+++ b/templates/js/check.js
@@ -1,25 +1,29 @@
 $(document).ready(function () {
-	setInterval(function () {
-		var gui_classes = $('#gui_class').val();
-		$.ajax({
-			type: 'GET',
-			url: 'Customizing/global/plugins/Services/UIComponent/UserInterfaceHook/CtrlMainMenu/checkCtrl.php?classes=' + gui_classes,
-			data: '',
-			contentType: 'application/json;',
-			success: function (data) {
-				if (data.status == true) {
-					$('#gui_class').removeClass('ilctrl_failure');
-					$('#gui_class').addClass('ilctrl_ok');
-				} else {
-					$('#gui_class').removeClass('ilctrl_ok');
-					$('#gui_class').addClass('ilctrl_failure');
+	var checkGuiClasses = function () {
+			var gui_classes = $('#gui_class').val();
+			$.ajax({
+				type: 'GET',
+				url: 'Customizing/global/plugins/Services/UIComponent/UserInterfaceHook/CtrlMainMenu/checkCtrl.php?classes=' + gui_classes,
+				data: '',
+				contentType: 'application/json;',
+				success: function (data) {
+					if (data.status == true) {
+						$('#gui_class').removeClass('ilctrl_failure');
+						$('#gui_class').addClass('ilctrl_ok');
+					} else {
+						$('#gui_class').removeClass('ilctrl_ok');
+						$('#gui_class').addClass('ilctrl_failure');
+					}
+				},
+				error: function (xhr, ajaxOptions, thrownError) {
+					console.log('error...', xhr);
+				},
+				complete: function () {
 				}
-			},
-			error: function (xhr, ajaxOptions, thrownError) {
-				console.log('error...', xhr);
-			},
-			complete: function () {
-			}
-		});
-	}, 1000);
+			});
+	};
+	checkGuiClasses();
+	$('#gui_class').keyup(function () {
+		checkGuiClasses()
+	});
 });


### PR DESCRIPTION
When editing a menu entry of type ilCtrl, there is an asynchronous call fired once a second to check the GUI classes. This creates considerable overhead, as an instance of ILIAS is created in the background.
The following fires requests only when the text entered into the GUI classes input field changes.
